### PR TITLE
[SELECTION] Use correct key property so that selected document (opene…

### DIFF
--- a/src/VisualMain.ts
+++ b/src/VisualMain.ts
@@ -288,7 +288,7 @@ export default class CardBrowser8D7CFFDA2E7E400C9474F41B9EDBBA58 implements IVis
     private loadSelectionFromPowerBI() {
         if (this.selectedData !== null) {
             const card = this.cards.cardInstances.find(card =>
-                    (this.selectedData.find(element => card.data.selectionId.key === element['key']))
+                    (this.selectedData.find(element => card.data.selectionId.key === element['key'].key))
             );
             if (card) {
                 this.cards.updateReaderContent(card, card.data);


### PR DESCRIPTION
…d reader) is preserved across updates triggered by cross selection